### PR TITLE
todoの編集用メソッドの作成

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -36,8 +36,39 @@ class DatabaseHelper {
     });
   }
 
+  Future<Todo> getTodoById(int id) async {
+    // データベースから指定したIDのTodoを取得
+    List<Map<String, dynamic>> maps = await _database!.query(
+      'todos',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+
+    // データベースからのクエリ結果をTodoオブジェクトに変換
+    if (maps.isNotEmpty) {
+      return Todo.fromMap(maps.first);
+      // Todoオブジェクトを返す
+    } else {
+      throw Exception('Todo not found'); // Todoが見つからない場合は例外をスロー
+    }
+  }
+
   Future<void> insertTodo(Todo todo) async {
     await _database?.insert('todos', todo.toMap());
+  }
+
+  Future<void> updateTodo(int id, String title, int isCompleted) async {
+    final db = _database;
+    final values = <String, dynamic>{
+      "title": title,
+      "isCompleted": isCompleted,
+    };
+    await db!.update(
+      "todos",
+      values,
+      where: "id=?",
+      whereArgs: [id],
+    );
   }
 
   bool _isDatabaseInitialized() {

--- a/lib/todo.dart
+++ b/lib/todo.dart
@@ -12,4 +12,12 @@ class Todo {
       'isCompleted': isCompleted,
     };
   }
+
+  factory Todo.fromMap(Map<String, dynamic> map) {
+    return Todo(
+      id: map['id'],
+      title: map['title'],
+      isCompleted: map['isCompleted'],
+    );
+  }
 }

--- a/lib/todo_add_dialog.dart
+++ b/lib/todo_add_dialog.dart
@@ -28,7 +28,7 @@ class TodoAddDialog extends StatelessWidget {
           onPressed: () {
             String todoTitle = _textFieldController.text;
             todoBloc.add(
-              AddTodo(
+              AddTodoEvent(
                 todo: Todo(title: todoTitle, isCompleted: 0),
               ),
             );

--- a/lib/todo_bloc.dart
+++ b/lib/todo_bloc.dart
@@ -1,14 +1,28 @@
 import 'package:fighting_games_memo/database_helper.dart';
 import 'package:fighting_games_memo/todo.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
 
 class TodoBloc extends Bloc<TodoEvent, TodoState> {
   final DatabaseHelper databaseHelper;
 
   TodoBloc({required this.databaseHelper}) : super(TodoInitial()) {
-    on<AddTodo>((event, emit) async {
+    on<AddTodoEvent>((event, emit) async {
       await databaseHelper.insertTodo(event.todo);
       emit(TodoAdded());
+    });
+
+    on<UpdateTodoEvent>((event, emit) async {
+      Todo oldTodo = await databaseHelper.getTodoById(event.id);
+      // データベースで指定されたTodoを更新
+      // 空の場合は元々の値をそのまま使う。
+      await databaseHelper.updateTodo(
+        event.id,
+        event.title ?? oldTodo.title,
+        event.isCompleted ?? oldTodo.isCompleted,
+      );
+      final todos = await databaseHelper.getTodos();
+      emit(TodosUpdates(todos));
     });
 
     on<LoadTodos>((event, emit) async {
@@ -19,25 +33,51 @@ class TodoBloc extends Bloc<TodoEvent, TodoState> {
 }
 
 // イベント
-abstract class TodoEvent {}
+abstract class TodoEvent extends Equatable {
+  const TodoEvent();
+  @override
+  List<Object> get props => [];
+}
 
-class AddTodo extends TodoEvent {
+class AddTodoEvent extends TodoEvent {
   final Todo todo;
 
-  AddTodo({required this.todo});
+  const AddTodoEvent({required this.todo});
+}
+
+class UpdateTodoEvent extends TodoEvent {
+  final int id;
+  final String? title;
+  final int? isCompleted;
+
+  const UpdateTodoEvent({
+    required this.id,
+    this.title,
+    this.isCompleted,
+  });
 }
 
 class LoadTodos extends TodoEvent {}
 
 // ステート
-abstract class TodoState {}
+abstract class TodoState extends Equatable {
+  const TodoState();
+  @override
+  List<Object> get props => [];
+}
 
 class TodoInitial extends TodoState {}
 
 class TodosLoaded extends TodoState {
   final List<Todo> todos;
 
-  TodosLoaded(this.todos);
+  const TodosLoaded(this.todos);
+}
+
+class TodosUpdates extends TodoState {
+  final List<Todo> todos;
+
+  const TodosUpdates(this.todos);
 }
 
 class TodoAdded extends TodoState {}

--- a/lib/todo_list_page.dart
+++ b/lib/todo_list_page.dart
@@ -26,37 +26,60 @@ class TodoListPage extends StatelessWidget {
           );
         },
       ),
-      body: BlocListener<TodoBloc, TodoState>(
-        listener: (context, state) {},
-        child: BlocBuilder<TodoBloc, TodoState>(
-          builder: (context, state) {
-            if (state is TodoInitial) {
-              BlocProvider.of<TodoBloc>(context).add(LoadTodos());
-              return const Center(child: CircularProgressIndicator());
-            } else if (state is TodosLoaded) {
-              final todos = state.todos;
-              return ListView.builder(
-                itemCount: todos.length,
-                itemBuilder: (context, index) {
-                  var todo = todos[index];
-                  return ListTile(
-                    title: Text(todo.title),
-                    subtitle: Text('ID: ${todo.id}'),
-                    trailing: Checkbox(
-                      value: todo.isCompleted == 1,
-                      onChanged: (bool? value) {
-                        // Todoの完了状態を更新する処理を追加することができます
-                      },
-                    ),
-                  );
-                },
-              );
-            } else {
-              debugPrint(state.toString());
-              return const Center(child: Text('エラーが発生しました'));
-            }
-          },
-        ),
+      body: BlocBuilder<TodoBloc, TodoState>(
+        builder: (context, state) {
+          if (state is TodoInitial) {
+            BlocProvider.of<TodoBloc>(context).add(LoadTodos());
+            return const Center(child: CircularProgressIndicator());
+          } else if (state is TodosLoaded) {
+            final todos = state.todos;
+            return ListView.builder(
+              itemCount: todos.length,
+              itemBuilder: (context, index) {
+                var todo = todos[index];
+                return ListTile(
+                  title: Text(todo.title),
+                  subtitle: Text('ID: ${todo.id}'),
+                  trailing: Checkbox(
+                    value: todo.isCompleted == 1,
+                    onChanged: (bool? value) {
+                      debugPrint("リストがタップされました。 ${todo.isCompleted}");
+                      BlocProvider.of<TodoBloc>(context).add(UpdateTodoEvent(
+                          id: todo.id!,
+                          isCompleted: todo.isCompleted == 1 ? 0 : 1));
+                      BlocProvider.of<TodoBloc>(context).add(LoadTodos());
+                    },
+                  ),
+                );
+              },
+            );
+          } else if (state is TodosUpdates) {
+            final todos = state.todos;
+            return ListView.builder(
+              itemCount: todos.length,
+              itemBuilder: (context, index) {
+                var todo = todos[index];
+                return ListTile(
+                  title: Text(todo.title),
+                  subtitle: Text('ID: ${todo.id}'),
+                  trailing: Checkbox(
+                    value: todo.isCompleted == 1,
+                    onChanged: (bool? value) {
+                      debugPrint("リストがタップされました。 ${todo.isCompleted}");
+                      BlocProvider.of<TodoBloc>(context).add(UpdateTodoEvent(
+                          id: todo.id!,
+                          isCompleted: todo.isCompleted == 1 ? 0 : 1));
+                      BlocProvider.of<TodoBloc>(context).add(LoadTodos());
+                    },
+                  ),
+                );
+              },
+            );
+          } else {
+            BlocProvider.of<TodoBloc>(context).add(LoadTodos());
+            return const Center(child: CircularProgressIndicator());
+          }
+        },
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   sqflite:
   flutter_bloc:
   cupertino_icons: ^1.0.2
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
todoの編集用メソッドの作成。
今回の修正では、チェックボックスのタップ時に、isCompletedを0or1に変換する使い方。
todoの要素を増やした際にも応用可能。（メモを後から追加したり、期日を設定したり...）